### PR TITLE
Adding tests for console, ip, setup-cdk commands, dns, better ssh solution

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -6,6 +6,8 @@ iso_url : ""
 RHN_USERNAME : ""
 RHN_PASSWORD : ""
 
+#Set if tested binary is upstream minishift or downstream cdk (yes/no, y/n, true/false)
+Is_Downstream :
 #Set the project inputs (python project name, python registry path and python service name). It uses image from redhat registry.
 openshift_python_PROJECT : "test-python27"
 openshift_python_REGISTRY : "registry.access.redhat.com/rhscl/python-27-rhel7~https://github.com/openshift/django-ex" 
@@ -30,7 +32,6 @@ service_php_NAME : "cakephp-example"
 openshift_nodejsmongodb_PROJECT : "test-nodejs-mongodb"
 openshift_nodejsmongodb_TEMPLATE : "nodejs-mongodb-example" 
 service_nodejsmongodb_NAME : "nodejs-mongodb-example"
-
 
 
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,7 +1,9 @@
-Hypervisor_Provider : "kvm"
-minishift_PATH : "/home/agajdosi/minishift/minishift"
-minishift_lib_MODULE : "/home/agajdosi/git/cdk-minishift-testsuite/library/minishift_testlib.py"
+Hypervisor_Provider : ""
+minishift_PATH : ""
+minishift_lib_MODULE : ""
 Provisioning_OpenShift : ""
+iso_url : ""
+
 #Set the project inputs (python project name, python registry path and python service name). It uses image from redhat registry.
 openshift_python_PROJECT : "test-python27"
 openshift_python_REGISTRY : "registry.access.redhat.com/rhscl/python-27-rhel7~https://github.com/openshift/django-ex" 
@@ -26,9 +28,3 @@ service_php_NAME : "cakephp-example"
 openshift_nodejsmongodb_PROJECT : "test-nodejs-mongodb"
 openshift_nodejsmongodb_TEMPLATE : "nodejs-mongodb-example" 
 service_nodejsmongodb_NAME : "nodejs-mongodb-example"
-
-iso_url : "https://github.com/minishift/minishift-centos-iso/releases/download/v1.0.0-alpha.1/minishift-centos.iso"
-iso_url : "http://cdk-builds.usersys.redhat.com/builds/weekly/26-Dec-2016.3_0.alpha/minishift-rhel.iso"
-iso_url : ""
-
-

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,7 +1,6 @@
-Hypervisor_Provider : ""
-iso_url : ""
-minishift_PATH : ""
-minishift_lib_MODULE : ""
+Hypervisor_Provider : "kvm"
+minishift_PATH : "/home/agajdosi/minishift/minishift"
+minishift_lib_MODULE : "/home/agajdosi/git/cdk-minishift-testsuite/library/minishift_testlib.py"
 Provisioning_OpenShift : ""
 #Set the project inputs (python project name, python registry path and python service name). It uses image from redhat registry.
 openshift_python_PROJECT : "test-python27"
@@ -27,3 +26,9 @@ service_php_NAME : "cakephp-example"
 openshift_nodejsmongodb_PROJECT : "test-nodejs-mongodb"
 openshift_nodejsmongodb_TEMPLATE : "nodejs-mongodb-example" 
 service_nodejsmongodb_NAME : "nodejs-mongodb-example"
+
+iso_url : "https://github.com/minishift/minishift-centos-iso/releases/download/v1.0.0-alpha.1/minishift-centos.iso"
+iso_url : "http://cdk-builds.usersys.redhat.com/builds/weekly/26-Dec-2016.3_0.alpha/minishift-rhel.iso"
+iso_url : ""
+
+

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,9 +1,11 @@
-Hypervisor_Provider : "kvm"
-minishift_PATH : "/home/agajdosi/minishift/minishift"
-minishift_lib_MODULE : "/home/agajdosi/git/cdk-minishift-testsuite/library/minishift_testlib.py"
+Hypervisor_Provider : ""
+minishift_PATH : ""
+minishift_lib_MODULE : ""
 Provisioning_OpenShift : ""
+iso_url : ""
 RHN_USERNAME : ""
 RHN_PASSWORD : ""
+
 #Set the project inputs (python project name, python registry path and python service name). It uses image from redhat registry.
 openshift_python_PROJECT : "test-python27"
 openshift_python_REGISTRY : "registry.access.redhat.com/rhscl/python-27-rhel7~https://github.com/openshift/django-ex" 
@@ -29,8 +31,7 @@ openshift_nodejsmongodb_PROJECT : "test-nodejs-mongodb"
 openshift_nodejsmongodb_TEMPLATE : "nodejs-mongodb-example" 
 service_nodejsmongodb_NAME : "nodejs-mongodb-example"
 
-iso_url : "https://github.com/minishift/minishift-centos-iso/releases/download/v1.0.0-alpha.1/minishift-centos.iso"
-iso_url : "http://cdk-builds.usersys.redhat.com/builds/weekly/26-Dec-2016.3_0.alpha/minishift-rhel.iso"
-iso_url : ""
+
+
 
 

--- a/minishift_sanity.py
+++ b/minishift_sanity.py
@@ -164,11 +164,11 @@ class minishiftSanity(Test):
         cmd = "minishift stop"
         self.log.info("Stopping minishift...")
         child = pexpect.spawn(cmd)
-        index = child.expect(["Machine stopped.", pexpect.EOF, pexpect.TIMEOUT], timeout=60)
+        index = child.expect(["Cluster stopped.", pexpect.EOF, pexpect.TIMEOUT], timeout=60)
         if index==0:
-            self.log.info("Machine stopped.")
+            self.log.info("Cluster stopped.")
         else:
-            self.fail("Error while stopping the machine")
+            self.fail("Error while stopping the cluster.")
             
     def test_ms_repetetive_use(self):
         self.log.info("Testing repetetive use of minishifrt (start-stop-start...)")
@@ -184,6 +184,6 @@ class minishiftSanity(Test):
         child = pexpect.spawn(cmd)
         index = child.expect(["Machine deleted", "Host does not exist", pexpect.EOF, pexpect.TIMEOUT],timeout=60)
         if index==0:
-            self.log.info("Machine deleted.")
+            self.log.info("Minishift VM deleted.")
         else:
             self.fail("Delete attempt failed.")

--- a/minishift_sanity.py
+++ b/minishift_sanity.py
@@ -106,7 +106,7 @@ class minishiftSanity(Test):
         else:
             self.fail("Minishift start failed")
 	
-    def test_ms_console(self):
+    def atest_ms_console(self):
         cmd = "minishift console --url"
         self.log.info("Running command: " + cmd)
         child = pexpect.spawn(cmd)

--- a/minishift_sanity.py
+++ b/minishift_sanity.py
@@ -170,7 +170,7 @@ class minishiftSanity(Test):
         else:
             self.fail("Error while stopping the machine")
             
-    def test_ms_repetetive_use(self):
+    def atest_ms_repetetive_use(self):
         self.log.info("Testing repetetive use of minishifrt (start-stop-start...)")
         for x in range(5):
             self.test_ms_start()

--- a/minishift_sanity.py
+++ b/minishift_sanity.py
@@ -140,6 +140,7 @@ class minishiftSanity(Test):
             self.log.info("iso_url not specified, starting minishift without --iso-url flag")
         child = pexpect.spawn(cmd)
         index = child.expect(["The server is accessible via web console at:", pexpect.EOF, pexpect.TIMEOUT], timeout=600)
+        time.sleep(10)
         if index==0:
             self.log.info("Minishift start finished, OpenShift is started")
         else:
@@ -204,6 +205,7 @@ class minishiftSanity(Test):
         cmd = "ping -c 5 twitter.com"
         child = pexpect.spawn(cmd)
         index = child.expect (["0 received", "received", pexpect.EOF, pexpect.TIMEOUT], timeout=30)
+        time.sleep(10)
         if index==1:
             self.log.info("Host ping to twitter.com was successful")
         else:

--- a/minishift_sanity.py
+++ b/minishift_sanity.py
@@ -100,7 +100,7 @@ class minishiftSanity(Test):
             cmd = "minishift start"
             self.log.info("iso_url not specified, starting minishift without --iso-url flag")
         child = pexpect.spawn(cmd)
-        index = child.expect(["The server is accessible via web console at:", pexpect.EOF, pexpect.TIMEOUT], timeout=300)
+        index = child.expect(["The server is accessible via web console at:", pexpect.EOF, pexpect.TIMEOUT], timeout=600)
         if index==0:
             self.log.info("Minishift start finished, OpenShift is started")
         else:

--- a/minishift_sanity.py
+++ b/minishift_sanity.py
@@ -120,10 +120,10 @@ class minishiftSanity(Test):
         self.log.info("CDK Installation successful")
 
     def test_ms_start(self):
-	      if self.iso_url:
-	          cmd = "minishift start --show-libmachine-logs --v=5 --iso-url " + self.iso_url
+	if self.iso_url:
+	    cmd = "minishift start --show-libmachine-logs --v=5 --iso-url " + self.iso_url
             self.log.info("iso_url specified, starting minishift with --iso-url flag: " + self.iso_url)
-	      else:
+	else:
             cmd = "minishift start --show-libmachine-logs --v=5"
             self.log.info("iso_url not specified, starting minishift without --iso-url flag")
         child = pexpect.spawn(cmd)

--- a/minishift_sanity.py
+++ b/minishift_sanity.py
@@ -105,6 +105,22 @@ class minishiftSanity(Test):
             self.log.info("Minishift start finished, OpenShift is started")
         else:
             self.fail("Minishift start failed")
+	
+    def test_ms_console(self):
+        cmd = "minishift console --url"
+        self.log.info("Running command: " + cmd)
+        child = pexpect.spawn(cmd)
+        console_url = child.read()[:-2]
+        self.log.info("Returned url of console: " + console_url)
+
+        cmd = "curl " + console_url + "/console/ --insecure"
+        self.log.info("Running command: " + cmd)
+        child = pexpect.spawn(cmd)
+        index = child.expect(['<title>OpenShift Web Console</title>', '"status": "Failure"', pexpect.TIMEOUT], timeout=10)
+        if index == 0:
+            self.log.info("Command returned valid page - has <title>OpenShift Web Console</title>")
+        else:
+            self.fail("Command did not returned valid page")
             
     def test_python_project(self):
         new_project(self, self.params.get('openshift_python_PROJECT'), self.params.get('openshift_python_REGISTRY'), self.params.get('service_python_NAME'))

--- a/minishift_sanity.py
+++ b/minishift_sanity.py
@@ -58,6 +58,7 @@ class minishiftSanity(Test):
         Arg:
             self (object): Object of the current method
         '''
+	global minishift
         minishift = imp.load_source('minishift', self.params.get('minishift_lib_MODULE'))
         self.log.info("###########################################################################################")
         self.log.info("Avocado version : %s" % VERSION)
@@ -102,36 +103,29 @@ class minishiftSanity(Test):
             self.fail("Minishift start failed")
             
     def test_python_project(self):
-        
         new_project(self, self.params.get('openshift_python_PROJECT'), self.params.get('openshift_python_REGISTRY'), self.params.get('service_python_NAME'))
         
     def test_ruby_project(self):
-        
         clean_failed_app(self, self.params.get('openshift_python_PROJECT'))
         new_project(self, self.params.get('openshift_ruby_PROJECT'), self.params.get('openshift_ruby_REGISTRY'), self.params.get('service_ruby_NAME'))
     
     def test_perl_project(self):
-        
         clean_failed_app(self, self.params.get('openshift_ruby_PROJECT'))
         new_project(self, self.params.get('openshift_perl_PROJECT'), self.params.get('openshift_perl_REGISTRY'), self.params.get('service_perl_NAME'))
     
     def test_nodejs_project(self):
-        
         clean_failed_app(self, self.params.get('openshift_perl_PROJECT'))
         new_project(self, self.params.get('openshift_nodejs_PROJECT'), self.params.get('openshift_nodejs_REGISTRY'), self.params.get('service_nodejs_NAME'))
     
     def test_php_project(self):
-        
         clean_failed_app(self, self.params.get('openshift_nodejs_PROJECT'))
         new_project(self, self.params.get('openshift_php_PROJECT'), self.params.get('openshift_php_template'), self.params.get('service_php_NAME'), tempalte = True)
     
     def test_nodejs_mongodb_template(self):
-        
         clean_failed_app(self, self.params.get('openshift_php_PROJECT'))
         new_project(self, self.params.get('openshift_nodejsmongodb_PROJECT'), self.params.get('openshift_nodejsmongodb_TEMPLATE'), self.params.get('service_nodejsmongodb_NAME'), tempalte = True, dbservicename = "mongodb")
     
     def test_logout(self):
-        
         clean_failed_app(self, self.params.get('openshift_nodejsmongodb_PROJECT'))
         output = minishift.oc_logout(self)
         logout_str = "Logged " +"\"" +self.params.get('openshift_USERNAME') +"\"" +" out on " +"\"https://"

--- a/minishift_sanity.py
+++ b/minishift_sanity.py
@@ -182,7 +182,7 @@ class minishiftSanity(Test):
         #self.test_ms_stop()
         cmd = "minishift delete"
         child = pexpect.spawn(cmd)
-        index = child.expect(["Machine deleted", "Host does not exist", pexpect.EOF, pexpect.TIMEOUT],timeout=60)
+        index = child.expect(["Minishift VM deleted.", "Host does not exist", pexpect.EOF, pexpect.TIMEOUT],timeout=60)
         if index==0:
             self.log.info("Minishift VM deleted.")
         else:

--- a/minishift_sanity.py
+++ b/minishift_sanity.py
@@ -112,7 +112,7 @@ class minishiftSanity(Test):
         self.log.info("Running command: " + cmd)
         child = pexpect.spawn(cmd)
         index = child.expect(["CDK 3 setup complete.", pexpect.EOF, pexpect.TIMEOUT], timeout=30)
-        self.log.info("Console output: \n" + child.before + child.after)
+        self.log.info("Console output: \n" + str(child.before) + str(child.after))
         if not index==0:
             self.fail("CDK setup failed")
         self.log.info("Checking if rhel.iso exists")
@@ -144,7 +144,7 @@ class minishiftSanity(Test):
             self.log.info(" - running command: " + cmd)
         child = pexpect.spawn(cmd)
         index = child.expect(["The server is accessible via web console at:", pexpect.EOF, pexpect.TIMEOUT], timeout=600)
-        self.log.info("Console output: \n" + child.before + child.after)
+        self.log.info("Console output: \n" + str(child.before) + str(child.after))
         time.sleep(10)
         if index==0:
             self.log.info("Minishift start finished, OpenShift is started")
@@ -155,7 +155,7 @@ class minishiftSanity(Test):
         child = pexpect.spawn("minishift ssh")
 	child.sendline("whoami")
 	index = child.expect(["docker", pexpect.EOF, pexpect.TIMEOUT], timeout=10)
-	self.log.info("Console output: \n" + child.before + child.after)
+	self.log.info("Console output: \n" + str(child.before) + str(child.after))
         if index==0:
             self.log.info("Minishift ssh was successful")
         else:
@@ -172,7 +172,7 @@ class minishiftSanity(Test):
         self.log.info("Running command: " + cmd)
         child = pexpect.spawn(cmd)
         index = child.expect(['<title>OpenShift Web Console</title>', '"status": "Failure"', pexpect.TIMEOUT], timeout=10)
-        self.log.info("Console output: \n" + child.before + child.after)
+        self.log.info("Console output: \n" + str(child.before) + str(child.after))
         if index == 0:
             self.log.info("Command returned valid page - has <title>OpenShift Web Console</title>")
         else:
@@ -188,7 +188,7 @@ class minishiftSanity(Test):
         cmd = "ping -c 5 " + machine_ip
         child = pexpect.spawn(cmd)
         index = child.expect (["5 received", "received", pexpect.EOF, pexpect.TIMEOUT], timeout=30)
-        self.log.info("Console output: \n" + child.before + child.after)
+        self.log.info("Console output: \n" + str(child.before) + str(child.after))
         if index==0:
             self.log.info("Ping successful")
         else:
@@ -201,7 +201,7 @@ class minishiftSanity(Test):
         child = pexpect.spawn(cmd)
         child.sendline("ping -c 5 twitter.com")
         index = child.expect (["0 received", "received", pexpect.EOF, pexpect.TIMEOUT], timeout=30)
-        self.log.info("Console output: \n" + child.before + child.after)
+        self.log.info("Console output: \n" + str(child.before) + str(child.after))
         if index==1:
             self.log.info("Guest ping to twitter.com was successful")
         else:
@@ -213,7 +213,7 @@ class minishiftSanity(Test):
         cmd = "ping -c 5 twitter.com"
         child = pexpect.spawn(cmd)
         index = child.expect (["0 received", "received", pexpect.EOF, pexpect.TIMEOUT], timeout=30)
-        self.log.info("Console output: \n" + child.before + child.after)
+        self.log.info("Console output: \n" + str(child.before) + str(child.after))
         if index==1:
             self.log.info("Host ping to twitter.com was successful")
         else:
@@ -255,14 +255,14 @@ class minishiftSanity(Test):
         self.log.info("Stopping minishift...")
         child = pexpect.spawn(cmd)
         index = child.expect(["Cluster stopped.", pexpect.EOF, pexpect.TIMEOUT], timeout=60)
-        self.log.info("Console output: \n" + child.before + child.after)
+        self.log.info("Console output: \n" + str(child.before) + str(child.after))
         time.sleep(10)
         if index==0:
             self.log.info("Cluster stopped.")
         else:
             self.fail("Error while stopping the cluster.")
             
-    def test_repetetive_use(self):
+    def atest_repetetive_use(self):
         self.log.info("Testing repetetive use of minishifrt (start-stop-start...)")
         for x in range(5):
             self.test_ms_start()
@@ -274,7 +274,7 @@ class minishiftSanity(Test):
         cmd = "minishift delete"
         child = pexpect.spawn(cmd)
         index = child.expect(["Minishift VM deleted", "Host does not exist", pexpect.EOF, pexpect.TIMEOUT],timeout=60)
-        self.log.info("Console output: \n" + child.before + child.after)
+        self.log.info("Console output: \n" + str(child.before) + str(child.after))
         if index==0:
             self.log.info("Minishift VM deleted.")
         else:

--- a/minishift_sanity.py
+++ b/minishift_sanity.py
@@ -93,8 +93,12 @@ class minishiftSanity(Test):
     
     """        
     def test_ms_start(self):
-        cmd = "minishift start"
-        self.log.info("Starting minishift...")
+	if self.iso_url:
+	    cmd = "minishift start --iso-url " + self.iso_url
+            self.log.info("iso_url specified, starting minishift with --iso-url flag: " + self.iso_url)
+	else:
+            cmd = "minishift start"
+            self.log.info("iso_url not specified, starting minishift without --iso-url flag")
         child = pexpect.spawn(cmd)
         index = child.expect(["The server is accessible via web console at:", pexpect.EOF, pexpect.TIMEOUT], timeout=120)
         if index==0:

--- a/minishift_sanity.py
+++ b/minishift_sanity.py
@@ -121,7 +121,7 @@ class minishiftSanity(Test):
 
     def test_ms_start(self):
 	if self.iso_url:
-	    cmd = "minishift start --show-libmachine-logs --v=5 --iso-url " + self.iso_url
+            cmd = "minishift start --show-libmachine-logs --v=5 --iso-url " + self.iso_url
             self.log.info("iso_url specified, starting minishift with --iso-url flag: " + self.iso_url)
 	else:
             cmd = "minishift start --show-libmachine-logs --v=5"

--- a/minishift_sanity.py
+++ b/minishift_sanity.py
@@ -90,8 +90,33 @@ class minishiftSanity(Test):
         else:
             self.fail("Minishift start failed")
             provision_path = None
+    """
     
-    """        
+    def test_ms_setup_cdk(self):
+        '''
+        Testing if setup-cdk command is able to setup CDK properly:
+        RHEL iso and OCP binary are in place
+        '''
+        cmd = "minishift setup-cdk"
+        self.log.info("Running command: " + cmd)
+        child = pexpect.spawn(cmd)
+        index = child.expect(["CDK 3 setup complete.", pexpect.EOF, pexpect.TIMEOUT], timeout=30)
+        if not index==0:
+            self.fail("CDK setup failed")
+        self.log.info("Checking if rhel.iso exists")
+        exists = os.path.isfile( os.environ['HOME'] + "/.minishift/cache/iso/minishift-rhel.iso" )
+        if not exists:
+            self.fail("minishift-rhel.iso is not present")
+        self.log.info("Checking if oc binary exists")
+        exists = os.path.isfile( os.environ['HOME'] + "/.minishift/cache/oc/v3.4.0/oc" )
+        if not exists:
+            self.fail("oc binary is not present")
+        self.log.info("Checking if config.json exists")
+        exists = os.path.isfile( os.environ['HOME'] + "/.minishift/config/config.json" )
+        if not exists:
+            self.fail("config.json binary is not present")
+        self.log.info("CDK Installation successful")
+
     def test_ms_start(self):
 	if self.iso_url:
 	    cmd = "minishift start --iso-url " + self.iso_url
@@ -100,13 +125,23 @@ class minishiftSanity(Test):
             cmd = "minishift start"
             self.log.info("iso_url not specified, starting minishift without --iso-url flag")
         child = pexpect.spawn(cmd)
-        index = child.expect(["The server is accessible via web console at:", pexpect.EOF, pexpect.TIMEOUT], timeout=120)
+        index = child.expect(["The server is accessible via web console at:", pexpect.EOF, pexpect.TIMEOUT], timeout=600)
         if index==0:
             self.log.info("Minishift start finished, OpenShift is started")
         else:
             self.fail("Minishift start failed")
+
+    def test_ms_ssh(self):
+        child = pexpect.spawn("minishift ssh")
+	child.sendline("whoami")
+	index = child.expect(["docker", pexpect.EOF, pexpect.TIMEOUT], timeout=10)
+        if index==0:
+            self.log.info("Minishift ssh was successful")
+        else:
+            self.fail("Minishift ssh failed")
 	
     def test_ms_console(self):
+        ''' Testing if url of web console returned by minishift is accessible '''
         cmd = "minishift console --url"
         self.log.info("Running command: " + cmd)
         child = pexpect.spawn(cmd)
@@ -121,6 +156,45 @@ class minishiftSanity(Test):
             self.log.info("Command returned valid page - has <title>OpenShift Web Console</title>")
         else:
             self.fail("Command did not returned valid page")
+
+    def test_ms_ip(self):
+        ''' Testing if ip command gives right ip and host to guest ping is ok '''
+        cmd = "minishift ip"
+        self.log.info("Running command: " + cmd)
+        child = pexpect.spawn(cmd)
+        machine_ip = child.read()[:-2]
+        self.log.info("Returned host ip: " + machine_ip)
+        cmd = "ping -c 5 " + machine_ip
+        child = pexpect.spawn(cmd)
+        index = child.expect (["5 received", "received", pexpect.EOF, pexpect.TIMEOUT], timeout=30)
+        if index==0:
+            self.log.info("Ping successful")
+        else:
+            self.fail("Ping failed")
+
+    def test_dns_from_guest(self):
+        ''' Testing dns connection from guest to outside network '''
+        self.log.info("Checking dns from guest to outside network")
+        cmd = "minishift ssh"
+        child = pexpect.spawn(cmd)
+        child.sendline("ping -c 5 twitter.com")
+        index = child.expect (["0 received", "received", pexpect.EOF, pexpect.TIMEOUT], timeout=30)
+        if index==1:
+            self.log.info("Guest ping to twitter.com was successful")
+        else:
+            self.fail("Guest ping to twitter.com failed")
+
+    def test_dns_from_host(self):
+        ''' Testing dns connection from guest to outside network '''
+        self.log.info("Checking dns from guest to outside network")
+        cmd = "ping -c 5 twitter.com"
+        child = pexpect.spawn(cmd)
+        index = child.expect (["0 received", "received", pexpect.EOF, pexpect.TIMEOUT], timeout=30)
+        if index==1:
+            self.log.info("Host ping to twitter.com was successful")
+        else:
+            self.fail("Host ping to twitter.com failed")
+
             
     def test_python_project(self):
         new_project(self, self.params.get('openshift_python_PROJECT'), self.params.get('openshift_python_REGISTRY'), self.params.get('service_python_NAME'))
@@ -150,15 +224,6 @@ class minishiftSanity(Test):
         output = minishift.oc_logout(self)
         logout_str = "Logged " +"\"" +self.params.get('openshift_USERNAME') +"\"" +" out on " +"\"https://"
         self.assertIn(logout_str, output, "Failed to log out")
-            
-    def test_ms_ssh(self):
-        child = pexpect.spawn("minishift ssh")
-	child.sendline("whoami")
-	index = child.expect(["docker", pexpect.EOF, pexpect.TIMEOUT], timeout=10)
-        if index==0:
-            self.log.info("Minishift ssh was successful")
-        else:
-            self.fail("Minishift ssh failed")
 
     def test_ms_stop(self):
         cmd = "minishift stop"
@@ -170,7 +235,7 @@ class minishiftSanity(Test):
         else:
             self.fail("Error while stopping the cluster.")
             
-    def test_ms_repetetive_use(self):
+    def test_repetetive_use(self):
         self.log.info("Testing repetetive use of minishifrt (start-stop-start...)")
         for x in range(3):
             self.test_ms_start()
@@ -179,10 +244,9 @@ class minishiftSanity(Test):
     
     def test_ms_delete_existing(self):
         self.log.info("Trying to delete existing machine...")
-        #self.test_ms_stop()
         cmd = "minishift delete"
         child = pexpect.spawn(cmd)
-        index = child.expect(["Minishift VM deleted.", "Host does not exist", pexpect.EOF, pexpect.TIMEOUT],timeout=60)
+        index = child.expect(["Minishift VM deleted", "Host does not exist", pexpect.EOF, pexpect.TIMEOUT],timeout=60)
         if index==0:
             self.log.info("Minishift VM deleted.")
         else:

--- a/minishift_sanity.py
+++ b/minishift_sanity.py
@@ -112,6 +112,7 @@ class minishiftSanity(Test):
         self.log.info("Running command: " + cmd)
         child = pexpect.spawn(cmd)
         index = child.expect(["CDK 3 setup complete.", pexpect.EOF, pexpect.TIMEOUT], timeout=30)
+        self.log.info("Console output: \n" + child.before + child.after)
         if not index==0:
             self.fail("CDK setup failed")
         self.log.info("Checking if rhel.iso exists")
@@ -132,14 +133,19 @@ class minishiftSanity(Test):
         self.log.info("CDK Installation successful")
 
     def test_ms_start(self):
+        time.sleep(10)
 	if self.iso_url:
             cmd = "minishift start --iso-url " + self.iso_url + " --username " + self.RHN_Username + " --password " + self.RHN_Password
             self.log.info("iso_url specified, starting minishift with --iso-url flag: " + self.iso_url)
+            self.log.info(" - running command: " + cmd)
 	else:
             cmd = "minishift start " + " --username " + self.RHN_Username + " --password " + self.RHN_Password
             self.log.info("iso_url not specified, starting minishift without --iso-url flag")
+            self.log.info(" - running command: " + cmd)
         child = pexpect.spawn(cmd)
         index = child.expect(["The server is accessible via web console at:", pexpect.EOF, pexpect.TIMEOUT], timeout=600)
+        self.log.info("Console output: \n" + child.before + child.after)
+        time.sleep(10)
         if index==0:
             self.log.info("Minishift start finished, OpenShift is started")
         else:
@@ -149,6 +155,7 @@ class minishiftSanity(Test):
         child = pexpect.spawn("minishift ssh")
 	child.sendline("whoami")
 	index = child.expect(["docker", pexpect.EOF, pexpect.TIMEOUT], timeout=10)
+	self.log.info("Console output: \n" + child.before + child.after)
         if index==0:
             self.log.info("Minishift ssh was successful")
         else:
@@ -161,11 +168,11 @@ class minishiftSanity(Test):
         child = pexpect.spawn(cmd)
         console_url = child.read()[:-2]
         self.log.info("Returned url of console: " + console_url)
-
         cmd = "curl " + console_url + "/console/ --insecure"
         self.log.info("Running command: " + cmd)
         child = pexpect.spawn(cmd)
         index = child.expect(['<title>OpenShift Web Console</title>', '"status": "Failure"', pexpect.TIMEOUT], timeout=10)
+        self.log.info("Console output: \n" + child.before + child.after)
         if index == 0:
             self.log.info("Command returned valid page - has <title>OpenShift Web Console</title>")
         else:
@@ -181,6 +188,7 @@ class minishiftSanity(Test):
         cmd = "ping -c 5 " + machine_ip
         child = pexpect.spawn(cmd)
         index = child.expect (["5 received", "received", pexpect.EOF, pexpect.TIMEOUT], timeout=30)
+        self.log.info("Console output: \n" + child.before + child.after)
         if index==0:
             self.log.info("Ping successful")
         else:
@@ -193,6 +201,7 @@ class minishiftSanity(Test):
         child = pexpect.spawn(cmd)
         child.sendline("ping -c 5 twitter.com")
         index = child.expect (["0 received", "received", pexpect.EOF, pexpect.TIMEOUT], timeout=30)
+        self.log.info("Console output: \n" + child.before + child.after)
         if index==1:
             self.log.info("Guest ping to twitter.com was successful")
         else:
@@ -204,6 +213,7 @@ class minishiftSanity(Test):
         cmd = "ping -c 5 twitter.com"
         child = pexpect.spawn(cmd)
         index = child.expect (["0 received", "received", pexpect.EOF, pexpect.TIMEOUT], timeout=30)
+        self.log.info("Console output: \n" + child.before + child.after)
         if index==1:
             self.log.info("Host ping to twitter.com was successful")
         else:
@@ -240,10 +250,13 @@ class minishiftSanity(Test):
         self.assertIn(logout_str, output, "Failed to log out")
 
     def test_ms_stop(self):
+        time.sleep(10)
         cmd = "minishift stop"
         self.log.info("Stopping minishift...")
         child = pexpect.spawn(cmd)
         index = child.expect(["Cluster stopped.", pexpect.EOF, pexpect.TIMEOUT], timeout=60)
+        self.log.info("Console output: \n" + child.before + child.after)
+        time.sleep(10)
         if index==0:
             self.log.info("Cluster stopped.")
         else:
@@ -255,12 +268,13 @@ class minishiftSanity(Test):
             self.test_ms_start()
             self.test_ms_stop()
             self.log.info("Start-stop of machine OK - run number: " + str(x))
-    
+
     def test_ms_delete_existing(self):
         self.log.info("Trying to delete existing machine...")
         cmd = "minishift delete"
         child = pexpect.spawn(cmd)
         index = child.expect(["Minishift VM deleted", "Host does not exist", pexpect.EOF, pexpect.TIMEOUT],timeout=60)
+        self.log.info("Console output: \n" + child.before + child.after)
         if index==0:
             self.log.info("Minishift VM deleted.")
         else:

--- a/minishift_sanity.py
+++ b/minishift_sanity.py
@@ -132,6 +132,7 @@ class minishiftSanity(Test):
         self.log.info("CDK Installation successful")
 
     def test_ms_start(self):
+	time.sleep(10)
 	if self.iso_url:
             cmd = "minishift start --iso-url " + self.iso_url + " --username " + self.RHN_Username + " --password " + self.RHN_Password
             self.log.info("iso_url specified, starting minishift with --iso-url flag: " + self.iso_url)
@@ -205,7 +206,6 @@ class minishiftSanity(Test):
         cmd = "ping -c 5 twitter.com"
         child = pexpect.spawn(cmd)
         index = child.expect (["0 received", "received", pexpect.EOF, pexpect.TIMEOUT], timeout=30)
-        time.sleep(10)
         if index==1:
             self.log.info("Host ping to twitter.com was successful")
         else:
@@ -242,10 +242,12 @@ class minishiftSanity(Test):
         self.assertIn(logout_str, output, "Failed to log out")
 
     def test_ms_stop(self):
+	time.sleep(10)
         cmd = "minishift stop"
         self.log.info("Stopping minishift...")
         child = pexpect.spawn(cmd)
         index = child.expect(["Cluster stopped.", pexpect.EOF, pexpect.TIMEOUT], timeout=60)
+        time.sleep(10)
         if index==0:
             self.log.info("Cluster stopped.")
         else:

--- a/minishift_sanity.py
+++ b/minishift_sanity.py
@@ -100,7 +100,7 @@ class minishiftSanity(Test):
             cmd = "minishift start"
             self.log.info("iso_url not specified, starting minishift without --iso-url flag")
         child = pexpect.spawn(cmd)
-        index = child.expect(["The server is accessible via web console at:", pexpect.EOF, pexpect.TIMEOUT], timeout=600)
+        index = child.expect(["The server is accessible via web console at:", pexpect.EOF, pexpect.TIMEOUT], timeout=300)
         if index==0:
             self.log.info("Minishift start finished, OpenShift is started")
         else:

--- a/minishift_sanity.py
+++ b/minishift_sanity.py
@@ -100,7 +100,7 @@ class minishiftSanity(Test):
             cmd = "minishift start --show-libmachine-logs --v=5"
             self.log.info("iso_url not specified, starting minishift without --iso-url flag")
         child = pexpect.spawn(cmd)
-        index = child.expect(["The server is accessible via web console at:", pexpect.EOF, pexpect.TIMEOUT], timeout=300)
+        index = child.expect(["The server is accessible via web console at:", pexpect.EOF, pexpect.TIMEOUT], timeout=600)
         if index==0:
             self.log.info("Minishift start finished, OpenShift is started")
         else:
@@ -170,9 +170,9 @@ class minishiftSanity(Test):
         else:
             self.fail("Error while stopping the machine")
             
-    def atest_ms_repetetive_use(self):
+    def test_ms_repetetive_use(self):
         self.log.info("Testing repetetive use of minishifrt (start-stop-start...)")
-        for x in range(3):
+        for x in range(5):
             self.test_ms_start()
             self.test_ms_stop()
             self.log.info("Start-stop of machine OK - run number: " + str(x))

--- a/minishift_sanity.py
+++ b/minishift_sanity.py
@@ -94,10 +94,10 @@ class minishiftSanity(Test):
     """        
     def test_ms_start(self):
 	if self.iso_url:
-	    cmd = "minishift start --iso-url " + self.iso_url
+	    cmd = "minishift start --show-libmachine-logs --v=5 --iso-url " + self.iso_url
             self.log.info("iso_url specified, starting minishift with --iso-url flag: " + self.iso_url)
 	else:
-            cmd = "minishift start"
+            cmd = "minishift start --show-libmachine-logs --v=5"
             self.log.info("iso_url not specified, starting minishift without --iso-url flag")
         child = pexpect.spawn(cmd)
         index = child.expect(["The server is accessible via web console at:", pexpect.EOF, pexpect.TIMEOUT], timeout=300)

--- a/minishift_sanity.py
+++ b/minishift_sanity.py
@@ -100,36 +100,36 @@ class minishiftSanity(Test):
             cmd = "minishift start"
             self.log.info("iso_url not specified, starting minishift without --iso-url flag")
         child = pexpect.spawn(cmd)
-        index = child.expect(["The server is accessible via web console at:", pexpect.EOF, pexpect.TIMEOUT], timeout=120)
+        index = child.expect(["The server is accessible via web console at:", pexpect.EOF, pexpect.TIMEOUT], timeout=300)
         if index==0:
             self.log.info("Minishift start finished, OpenShift is started")
         else:
             self.fail("Minishift start failed")
             
-    def test_python_project(self):
+    def atest_python_project(self):
         new_project(self, self.params.get('openshift_python_PROJECT'), self.params.get('openshift_python_REGISTRY'), self.params.get('service_python_NAME'))
         
-    def test_ruby_project(self):
+    def atest_ruby_project(self):
         clean_failed_app(self, self.params.get('openshift_python_PROJECT'))
         new_project(self, self.params.get('openshift_ruby_PROJECT'), self.params.get('openshift_ruby_REGISTRY'), self.params.get('service_ruby_NAME'))
     
-    def test_perl_project(self):
+    def atest_perl_project(self):
         clean_failed_app(self, self.params.get('openshift_ruby_PROJECT'))
         new_project(self, self.params.get('openshift_perl_PROJECT'), self.params.get('openshift_perl_REGISTRY'), self.params.get('service_perl_NAME'))
     
-    def test_nodejs_project(self):
+    def atest_nodejs_project(self):
         clean_failed_app(self, self.params.get('openshift_perl_PROJECT'))
         new_project(self, self.params.get('openshift_nodejs_PROJECT'), self.params.get('openshift_nodejs_REGISTRY'), self.params.get('service_nodejs_NAME'))
     
-    def test_php_project(self):
+    def atest_php_project(self):
         clean_failed_app(self, self.params.get('openshift_nodejs_PROJECT'))
         new_project(self, self.params.get('openshift_php_PROJECT'), self.params.get('openshift_php_template'), self.params.get('service_php_NAME'), tempalte = True)
     
-    def test_nodejs_mongodb_template(self):
+    def atest_nodejs_mongodb_template(self):
         clean_failed_app(self, self.params.get('openshift_php_PROJECT'))
         new_project(self, self.params.get('openshift_nodejsmongodb_PROJECT'), self.params.get('openshift_nodejsmongodb_TEMPLATE'), self.params.get('service_nodejsmongodb_NAME'), tempalte = True, dbservicename = "mongodb")
     
-    def test_logout(self):
+    def atest_logout(self):
         clean_failed_app(self, self.params.get('openshift_nodejsmongodb_PROJECT'))
         output = minishift.oc_logout(self)
         logout_str = "Logged " +"\"" +self.params.get('openshift_USERNAME') +"\"" +" out on " +"\"https://"
@@ -154,7 +154,7 @@ class minishiftSanity(Test):
         else:
             self.fail("Error while stopping the machine")
             
-    def test_ms_repetetive_use(self):
+    def atest_ms_repetetive_use(self):
         self.log.info("Testing repetetive use of minishifrt (start-stop-start...)")
         for x in range(3):
             self.test_ms_start()

--- a/minishift_sanity.py
+++ b/minishift_sanity.py
@@ -132,11 +132,11 @@ class minishiftSanity(Test):
         self.assertIn(logout_str, output, "Failed to log out")
             
     def test_ms_ssh(self):
-        cmd = "minishift ssh"
-        child = pexpect.spawn(cmd)
-        index = child.expect(["Last login:", pexpect.EOF, pexpect.TIMEOUT], timeout=30)
+        child = pexpect.spawn("minishift ssh")
+	child.sendline("whoami")
+	index = child.expect(["docker", pexpect.EOF, pexpect.TIMEOUT], timeout=10)
         if index==0:
-            self.log.info("Minishift ssh successful")
+            self.log.info("Minishift ssh was successful")
         else:
             self.fail("Minishift ssh failed")
 

--- a/minishift_sanity.py
+++ b/minishift_sanity.py
@@ -123,11 +123,11 @@ class minishiftSanity(Test):
     
     def test_php_project(self):
         clean_failed_app(self, self.params.get('openshift_nodejs_PROJECT'))
-        new_project(self, self.params.get('openshift_php_PROJECT'), self.params.get('openshift_php_template'), self.params.get('service_php_NAME'), tempalte = True)
+        new_project(self, self.params.get('openshift_php_PROJECT'), self.params.get('openshift_php_template'), self.params.get('service_php_NAME'), template = True)
     
     def test_nodejs_mongodb_template(self):
         clean_failed_app(self, self.params.get('openshift_php_PROJECT'))
-        new_project(self, self.params.get('openshift_nodejsmongodb_PROJECT'), self.params.get('openshift_nodejsmongodb_TEMPLATE'), self.params.get('service_nodejsmongodb_NAME'), tempalte = True, dbservicename = "mongodb")
+        new_project(self, self.params.get('openshift_nodejsmongodb_PROJECT'), self.params.get('openshift_nodejsmongodb_TEMPLATE'), self.params.get('service_nodejsmongodb_NAME'), template = True, dbservicename = "mongodb")
     
     def test_logout(self):
         clean_failed_app(self, self.params.get('openshift_nodejsmongodb_PROJECT'))


### PR DESCRIPTION
Minishift var changed to be global.
In php and nodejs changed tempalte parameter to template.
Upgraded ssh test to test with "whoami", not return message of ssh, which is different on docker, centos-iso and rhel-iso.
Added support for --iso-url flag in minishift start - as we do not know, how exactly will start be implemented in CDK builds.