### PR TITLE
Dynamic search for oc binary

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,7 +1,6 @@
 Hypervisor_Provider : ""
 minishift_PATH : ""
 minishift_lib_MODULE : ""
-Provisioning_OpenShift : ""
 iso_url : ""
 openshift_USER : ""
 openshift_PASSWORD : ""

--- a/library/minishift_testlib.py
+++ b/library/minishift_testlib.py
@@ -6,7 +6,7 @@ import time
 
 log = logging.getLogger("Openshift.Debug")
 
-def wait_for_output(cmd, timeout = 60):
+def wait_for_output(cmd, timeout = 180):
     output = "FAIL"
     for i in range(timeout):
         time.sleep(1)
@@ -17,7 +17,7 @@ def wait_for_output(cmd, timeout = 60):
             pass
     return output
 
-def wait_for_text_in_output(cmd, text = '', timeout = 60):
+def wait_for_text_in_output(cmd, text = '', timeout = 180):
     output = "FAIL"
     for i in range(timeout):
         time.sleep(1)

--- a/minishift_sanity.py
+++ b/minishift_sanity.py
@@ -33,16 +33,16 @@ def new_project(self, projectname, registry, servicename, tempalte = False, dbse
         self.assertIn("exposed", output, "Service failed to expose " +projectname)
     else:
         pass
-                                
+
     output = minishift.routing_cdk(self, servicename, projectname)
     self.assertIn("HTTP/1.1 200 OK", output, "Service " +servicename +"-" +projectname +" fail to expose to outside")
-                                    
+
     output = minishift.oc_get_pod(self)
     self.assertIn("Running", output, "Failed to run pod")
-                                        
+
     output = minishift.oc_delete(self, projectname)
     self.assertIn("deleted", output, "Failed to delete " +projectname)
-    
+
 def clean_failed_app(self, projectname):
     output = minishift.oc_delete(self, projectname)
     if output == "FAIL":
@@ -66,13 +66,15 @@ class minishiftSanity(Test):
         self.log.info("###########################################################################################")
         self.Hypervisor_Provider = self.params.get('Hypervisor_Provider')
         self.iso_url = self.params.get('iso_url')
-        self.Provisioning_OpenShift = self.params.get('Provisioning_OpenShift')
         self.Is_Downstream = self.params.get('Is_Downstream')
         self.RHN_Username = self.params.get('RHN_USERNAME')
         self.RHN_Password = self.params.get('RHN_PASSWORD')
-        sys.path.append(self.params.get('minishift_PATH'))
-        sys.path.append(self.params.get('Provisioning_OpenShift'))
         self.log.info("Is downstream: ", self.Is_Downstream)
+        oc_binaries = glob.glob(os.environ['HOME'] + "/.minishift/cache/oc/v3.*/oc")
+        if oc_binaries:
+            self.log.info("adding oc binary into path: " + oc_binaries[0])
+            os.environ['PATH'] = oc_binaries[0] + ":" + os.environ['PATH']
+
 
     """    
     def test_ms_start(self):

--- a/minishift_sanity.py
+++ b/minishift_sanity.py
@@ -73,10 +73,10 @@ class minishiftSanity(Test):
         self.RHN_Username = self.params.get('RHN_USERNAME')
         self.RHN_Password = self.params.get('RHN_PASSWORD')
         self.log.info("Is downstream: ", self.Is_Downstream)
-        oc_binaries = glob.glob(os.environ['HOME'] + "/.minishift/cache/oc/v3.*/oc")
-        if oc_binaries:
-            self.log.info("adding oc binary into path: " + oc_binaries[0])
-            os.environ['PATH'] = oc_binaries[0] + ":" + os.environ['PATH']
+        oc_locations = glob.glob(os.environ['HOME'] + "/.minishift/cache/oc/v3.*/")
+        if oc_locations:
+            self.log.info("adding oc binary into path: " + oc_locations[0])
+            os.environ['PATH'] = oc_locations[0] + ":" + os.environ['PATH']
 
 
     """    

--- a/minishift_sanity.py
+++ b/minishift_sanity.py
@@ -120,10 +120,10 @@ class minishiftSanity(Test):
         self.log.info("Console output: \n" + str(child.before) + str(child.after))
         if not index==0:
             self.fail("CDK setup failed")
-        self.log.info("Checking if rhel.iso exists")
-        exists = os.path.isfile( os.environ['HOME'] + "/.minishift/cache/iso/minishift-rhel.iso" )
+        self.log.info("Checking if minishift-rhel7.iso exists")
+        exists = os.path.isfile( os.environ['HOME'] + "/.minishift/cache/iso/minishift-rhel7.iso" )
         if not exists:
-            self.fail("minishift-rhel.iso is not present")
+            self.fail("minishift-rhel7.iso is not present")
         self.log.info("Checking if oc binary exists")
         oc_binaries = glob.glob( os.environ['HOME'] + "/.minishift/cache/oc/v3.*")
         if not oc_binaries:


### PR DESCRIPTION
setUp() function now searches for oc binary at ~/.minishift/cache/oc. Detected folder for example v3.3.0.49 is then added into path so all tests can run "oc" command.